### PR TITLE
Removed use of "Short array syntax"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use \DrewM\Morse\Morse;
 
 if (Morse::featureExists('http/curl')) {
 	// use curl
-}else{
+} else {
 	// use sockets
 }
 ```
@@ -81,10 +81,10 @@ $best_match = Morse::getFirstAvailable(['image/gd', 'image/imagick']);
 or
 
 ```php
-$best_match = Morse::getFirstAvailable([
+$best_match = Morse::getFirstAvailable(array(
 					'image/gd' => 'gd', 
 					'image/imagick' => 'imagick'
-				]);
+				));
 
 switch($best_match) {
 


### PR DESCRIPTION
Removed use of "Short array syntax" to maintain PHP 5.3 Compatibility.
"Short array syntax" was included in PHP 5.4.0  http://php.net/manual/pt_BR/migration54.new-features.php